### PR TITLE
Close file descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clone this repo to the extensions folder:
 
 ```
 mkdir -p ~/.local/share/gnome-shell/extensions
-git clone https://github.com/form3tech-oss/gnome-globalprotect ~/.local/share/gnome-shell/extensions/gnomeglobalprotect@gnomeglobalprotect@form3tech-oss
+git clone https://github.com/form3tech-oss/gnome-globalprotect ~/.local/share/gnome-shell/extensions/gnomeglobalprotect@form3tech-oss
 ```
 
 Confirm PanGPUI is set as a startup program:


### PR DESCRIPTION
File descriptors were left dangling piling up over time.

Before:

```
$ lsof -P -n | grep gnome | grep pipe | wc -l
32

$ gnome-extensions enable gnomeglobalprotect@form3tech-oss

$ lsof -P -n | grep gnome | grep pipe | wc -l
112

# wait 20 seconds

$ lsof -P -n | grep gnome | grep pipe | wc -l
345
```

After:
```
lsof -P -n | grep gnome | grep pipe | wc -l
32

$ gnome-extensions enable gnomeglobalprotect@form3tech-oss

$ lsof -P -n | grep gnome | grep pipe | wc -l
32

# wait 20 seconds

$ lsof -P -n | grep gnome | grep pipe | wc -l
32
```

Fixes #4